### PR TITLE
feat: enforce structured confirmation for fund-moving commands

### DIFF
--- a/skills/minara/SKILL.md
+++ b/skills/minara/SKILL.md
@@ -98,7 +98,7 @@ Run `minara account` to check login state:
    - **Claude Code:** MUST use the **AskUserQuestion** tool. Do NOT use plain text chat.
    - **OpenClaw / other agents:** present numbered options in chat (e.g. "1) Confirm  2) Dry-run  3) Abort").
    - Include in the prompt: summary of the operation (action, token, amount, chain, recipient, current balance)
-   - Options: A) Confirm and execute (Recommended) / B) Dry-run (simulate only, if supported) / C) Abort
+   - Options: A) Confirm and execute (Recommended) / B) Abort
 3. **Wait for user's choice** before proceeding
 4. **If user selects Confirm:** execute the CLI command WITHOUT `-y`. Let the CLI show its own confirmation prompt, then answer `y` on the user's behalf (since they already confirmed)
 5. **If user selects Abort:** stop immediately


### PR DESCRIPTION
## Summary
- Enforce AskUserQuestion (Claude Code) or numbered options (OpenClaw) for all fund-moving transaction confirmations
- Ban `-y`/`--yes` flag usage — CLI's built-in confirmation is mandatory
- Allow natural language confirmation ("yes", "是的") after structured choices are presented
- Remove dry-run from confirmation options

## Changes
- `skills/minara/SKILL.md`: rewrite Transaction Confirmation section with explicit confirmation flow and banned behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)