### PR TITLE
docs(minara): add anti-loop safeguards for interactive CLI commands in agent environments

### DIFF
--- a/skills/minara/SKILL.md
+++ b/skills/minara/SKILL.md
@@ -97,6 +97,16 @@ Analysis (ask/research/chat) is read-only. **NEVER execute any fund-moving comma
 3. If the user did NOT express trade intent, do NOT suggest any trade.
 4. Wait for the user's explicit reply to start the confirmation flow.
 
+### ⚠ Anti-loop safeguard (MUST follow)
+
+Interactive CLI commands (pickers, multi-step prompts) can hang in agent environments. To prevent infinite retry loops:
+
+1. **Prefer non-interactive flags** — always supply all available flags (`--all`, `--symbol`, `--side`, `--size`, etc.) to skip interactive prompts. Read the reference doc to find the correct flags.
+2. **Max 1 retry** — if a command fails or hangs, retry at most once. After 2 failures, **STOP** and report the error to the user.
+3. **Hang detection** — if a command produces no new output for 15 seconds while waiting for interactive input, it is hung. Kill the process (do NOT keep waiting) and do NOT retry.
+4. **Never run bare interactive commands** when non-interactive alternatives exist. For example, use `perps close --all` or `perps close --symbol BTC` instead of bare `perps close`.
+5. **Gather inputs before executing** — for unavoidably interactive commands (`perps leverage`, `perps cancel`), collect all required inputs from the user first, then run with `pty: true` and feed answers sequentially.
+
 ## Transaction confirmation (CRITICAL — MUST follow exactly)
 
 **Fund-moving commands** (MUST confirm before executing):
@@ -210,7 +220,7 @@ Match user intent → read the **Reference** for full execution flow. All CLI co
 | "short BTC", "go short on ETH", "short SOL with 10x" | `perps order` (interactive) or `perps order -S short -s SYM -z SIZE` (direct) | `{baseDir}/references/perps-order.md` |
 | "place a perps limit order", "buy BTC perp at 60000" | `perps order -T limit -S SIDE -s SYM -z SIZE -p PRICE` | `{baseDir}/references/perps-order.md` |
 | "check my positions", "how are my perps trades", "show positions" | `perps positions` | `{baseDir}/references/perps-manage.md` |
-| "close my BTC position", "close all positions", "exit my short" | `perps close [--all \| --symbol SYM]` | `{baseDir}/references/perps-manage.md` |
+| "close my BTC position", "close all positions", "exit my short" | `perps close --all` or `perps close --symbol SYM` (⚠ NEVER bare `perps close`) | `{baseDir}/references/perps-manage.md` |
 | "cancel my perps order" | `perps cancel` | `{baseDir}/references/perps-manage.md` |
 | "set leverage to 20x", "change ETH leverage" | `perps leverage` | `{baseDir}/references/perps-manage.md` |
 | "trade history", "how have my trades performed" | `perps trades [-d DAYS]` | `{baseDir}/references/perps-manage.md` |

--- a/skills/minara/references/limit-order.md
+++ b/skills/minara/references/limit-order.md
@@ -2,17 +2,22 @@
 
 > Execute commands yourself. Use `pty: true` for interactive prompts.
 
+## ⚠ CRITICAL — Interactive commands (anti-loop)
+
+- `limit-order create` is **fully interactive** (multi-step prompts). Collect all inputs (chain, side, token, price condition, target price, amount, expiry) from the user first, then run with `pty: true` and feed answers sequentially.
+- `limit-order cancel` without an ID enters an **interactive picker**. Always run `limit-order list` first, then pass the specific order ID: `limit-order cancel ID`.
+- **Never run bare `minara limit-order`** (no subcommand) — it enters an interactive submenu that can hang.
+- **If any command hangs** (no output for 15s), kill it immediately. Do NOT retry. Max 1 retry total.
+
 ## Commands
 
 | Intent | CLI | Type |
 |--------|-----|------|
-| Create limit order | `minara limit-order create` | fund-moving |
+| Create limit order | `minara limit-order create` (pty) | fund-moving |
 | List active orders | `minara limit-order list` | read-only |
-| Cancel order by ID | `minara limit-order cancel [ID]` | fund-moving |
+| Cancel order by ID | `minara limit-order cancel ID` (⚠ always pass ID) | fund-moving |
 
 **Alias:** `minara lo` = `minara limit-order`
-
-**Default (no subcommand):** interactive submenu — create / list / cancel.
 
 ## `minara limit-order create`
 

--- a/skills/minara/references/perps-autopilot.md
+++ b/skills/minara/references/perps-autopilot.md
@@ -2,6 +2,15 @@
 
 > Execute commands yourself. Use `pty: true` — fully interactive dashboards.
 
+## ⚠ CRITICAL — Interactive commands (anti-loop)
+
+Both commands below are **fully interactive** (multi-step prompts). To prevent hang/retry loops:
+
+1. **Collect all inputs from user first** before running the command.
+2. Run with `pty: true` and feed answers sequentially.
+3. **If the command hangs** (no new output for 15s), kill it immediately. Do NOT retry. Report to user.
+4. **Max 1 retry** — after 2 failures, stop and report.
+
 ## Commands
 
 | Intent | CLI | Type |

--- a/skills/minara/references/perps-manage.md
+++ b/skills/minara/references/perps-manage.md
@@ -4,14 +4,29 @@
 >
 > **`perps leverage` is fund-moving** — changing leverage directly affects position risk and liquidation price. Present a confirmation summary (asset, current leverage → new leverage, margin mode, Hyperliquid) and STOP. Wait for user's explicit reply before executing.
 
+## ⚠ CRITICAL — Non-interactive mode FIRST (anti-loop)
+
+**ALWAYS prefer non-interactive flags** to avoid interactive picker prompts that can hang and cause retry loops.
+
+| Command | Non-interactive flags | NEVER run bare |
+|---------|----------------------|----------------|
+| `perps close` | `--all` or `--symbol SYM` | `perps close` (no flags) |
+| `perps cancel` | First run `perps positions` to identify the order, then use picker with pty | `perps cancel` blindly |
+| `perps leverage` | N/A — always interactive, see section below | — |
+
+**Anti-loop rules:**
+1. If a command hangs (no new output for 15 seconds) on an interactive prompt, **STOP — do NOT retry**. Kill the process and report to the user.
+2. **Max 1 retry** for any single command. If it fails twice, stop and report.
+3. Before running any perps manage command, decide which flags to use. Never run a bare interactive command hoping it will work.
+
 ## Commands
 
 | Intent | CLI | Type |
 |--------|-----|------|
 | View positions | `minara perps positions` | read-only |
-| Close position(s) | `minara perps close` | fund-moving |
-| Cancel open order(s) | `minara perps cancel` | fund-moving |
-| Set leverage | `minara perps leverage` | fund-moving |
+| Close position(s) | `minara perps close --all` or `--symbol SYM` | fund-moving |
+| Cancel open order(s) | `minara perps cancel` (pty) | fund-moving |
+| Set leverage | `minara perps leverage` (pty) | config |
 | Trade fill history | `minara perps trades` | read-only |
 
 All accept `-w, --wallet <name>` to target a specific sub-wallet.
@@ -34,11 +49,20 @@ Open Positions (2):
 
 **Options:** `-a, --all` (close ALL), `-s, --symbol <symbol>` (close by symbol), `-y, --yes`, `-w, --wallet`
 
+### Agent execution flow (MUST follow)
+
+1. **Run `minara perps positions`** first to see open positions.
+2. **Determine intent** from the user's request:
+   - "close all" / "close everything" → use `--all`
+   - "close BTC" / "close my ETH position" → use `--symbol SYM`
+   - Ambiguous → ask the user which position to close. **Do NOT run bare `perps close`.**
+3. Execute with the chosen flags.
+
 | Usage | Effect |
 |-------|--------|
-| `perps close` | Interactive: pick position from list |
 | `perps close --all` | Close all positions at market |
 | `perps close --symbol BTC` | Close all BTC positions |
+| ~~`perps close`~~ | ⛔ **DO NOT USE** — enters interactive picker, causes hang in Claude Code |
 
 Confirm + Touch ID before execution.
 
@@ -59,6 +83,16 @@ Cancel an open perps order. Interactive picker if no specific order.
 
 **Options:** `-y, --yes`, `-w, --wallet`
 
+### Agent execution flow (MUST follow)
+
+This command **always** uses an interactive picker. To avoid hanging:
+
+1. **First**, run `minara perps positions` to list open orders and identify which one to cancel.
+2. Tell the user which open orders exist and ask which one to cancel (use structured choices).
+3. Run `minara perps cancel` with `pty: true`.
+4. When the picker appears, select the matching order.
+5. **If the command hangs** (no output for 15s), kill it immediately. Do NOT retry. Report to the user.
+
 ```
 ? Select order to cancel: ETH BUY 0.5 @ $3,000 oid:12345
 ? Cancel? (y/N) y
@@ -73,6 +107,15 @@ Can be run interactively or with non-interactive flags.
 Options: `-s, --symbol <TOKEN>` (target token), `-l, --leverage <VALUE>` (leverage multiplier), `-w, --wallet <name>`.
 
 When both `-s` and `-l` are provided, it defaults to cross margin mode.
+
+### Agent execution flow (MUST follow)
+
+This command is **always interactive** (no non-interactive flags). Handle carefully:
+
+1. **Before running**, ask the user for all three inputs: asset, leverage multiplier, margin mode (cross/isolated).
+2. Run `minara perps leverage` with `pty: true`.
+3. Respond to each prompt in sequence with the user's specified values.
+4. **If the command hangs** (no output for 15s at any prompt), kill it immediately. Do NOT retry. Report to the user that the interactive command could not complete and suggest they run it manually.
 
 ```
 $ minara perps leverage -s ETH -l 20

--- a/skills/minara/references/perps-order.md
+++ b/skills/minara/references/perps-order.md
@@ -49,9 +49,13 @@ For limit orders, also provide `--type limit` and `--price`:
 $ minara perps order -T limit -S short -s ETH -z 0.5 -p 4000 --wallet Bot-1
 ```
 
-### Interactive mode (default)
+### Interactive mode (default) — ⚠ AVOID in Claude Code
 
-When any of `--side`/`--symbol`/`--size` is missing, CLI guides through prompts:
+When any of `--side`/`--symbol`/`--size` is missing, CLI guides through prompts. **This multi-step interactive flow can hang in agent environments and cause retry loops.**
+
+**Agent rule:** ALWAYS provide `--side`, `--symbol`, and `--size` to use non-interactive mode. Parse the user's intent to determine these values. If any value is unclear, ask the user — do NOT run the bare interactive command.
+
+Interactive prompt sequence (for reference only — prefer non-interactive mode):
 
 1. Resolve wallet (via `--wallet` or picker)
 2. **Autopilot check** — blocks if autopilot is ON for this wallet
@@ -62,6 +66,8 @@ When any of `--side`/`--symbol`/`--size` is missing, CLI guides through prompts:
 7. Reduce only? (default: No)
 8. Grouping: None / Normal TP/SL / Position TP/SL
 9. Preview → Confirm → Touch ID → Execute
+
+**If interactive mode is unavoidable and the command hangs** (no output for 15s), kill it immediately. Do NOT retry. Report to user.
 
 ### Autopilot guard
 


### PR DESCRIPTION
## Summary

Agents such as **Claude Code** often run the Minara CLI with a PTY. Interactive subcommands (pickers, multi-step prompts) can **block waiting for input**. When the tool times out or returns no progress, the model may **re-run the same command**, producing an apparent **infinite loop**—especially around **perps management** (`perps close`, `perps cancel`, `perps leverage`, etc.).

This change updates the Minara skill documentation to:

1. **Prefer non-interactive flags** wherever the CLI supports them (e.g. `perps close --all` / `--symbol` instead of bare `perps close`).
2. **Define explicit agent execution flows** in `perps-manage.md` (run `perps positions` first, then choose flags; structured choices before `perps cancel`; gather inputs before `perps leverage`).
3. **Add a global "Anti-loop safeguard"** section in `SKILL.md`: max one retry, hang detection (~15 seconds without new output), kill-and-report instead of blind retries, gather inputs before unavoidable interactive runs.
4. **Align related references** (`perps-order.md`, `limit-order.md`, `perps-autopilot.md`) with the same guidance so other interactive entry points do not regress.

**Scope:** documentation only (no executable code or CLI behavior changes).

## Problem

- Bare `minara perps close` opens an **interactive position picker**.
- Agent shells may not complete TTY flows reliably; the agent then **retries** the same invocation.
- Users observe a **retry / "dead loop"** when managing perps through the skill.

## Solution (documentation)

| File | Change |
|------|--------|
| `skills/minara/SKILL.md` | New **Anti-loop safeguard** subsection; perps close row stresses `--all` / `--symbol` and warns against bare `perps close`. |
| `skills/minara/references/perps-manage.md` | **Non-interactive first** table; anti-loop rules; step-by-step agent flows for close / cancel / leverage. |
| `skills/minara/references/perps-order.md` | Prefer passing `--side`, `--symbol`, `--size`; avoid bare interactive `perps order` in agents. |
| `skills/minara/references/limit-order.md` | Avoid bare `minara limit-order`; use `limit-order list` then `limit-order cancel <id>`. |
| `skills/minara/references/perps-autopilot.md` | Hang / retry guidance for fully interactive autopilot and `perps ask`. |

## Testing

- N/A (Markdown-only). Please sanity-check wording against existing rules (no `-y`, structured confirmation for fund-moving commands).

## Checklist

- [x] Documentation only; no secrets or new scripts.
- [x] Preserves existing transaction-confirmation and "never `-y`" rules.