### PR TITLE
ci: add crypto-skill-bench workflow

### DIFF
--- a/.github/workflows/crypto-skill-bench.yml
+++ b/.github/workflows/crypto-skill-bench.yml
@@ -1,0 +1,32 @@
+name: Crypto Skill Bench
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install crypto-skill-bench
+        run: npm install -g crypto-skill-bench
+
+      - name: Run benchmark (CI mode)
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: crypto-skill-bench evaluate ./skills/minara --ci
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-report
+          path: reports/


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that runs `crypto-skill-bench evaluate` with `--ci` flag on push/PR to `main`
- Safety gate failure will block the merge (exit code 1)
- Benchmark reports uploaded as artifacts on every run

## Prerequisites
- `OPENROUTER_API_KEY` must be configured in repo secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)