### PR TITLE
Drop labels below logos for a cleaner Works-with row

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Turn your AI agent into a personal AI CFO. [Minara](https://minara.ai) skills gi
   <tr>
     <td align="center" width="140"><h3>Works<br>with</h3></td>
     <td align="center" width="140">
-      <a href="https://openclaw.ai/"><img src="assets/openclaw-logo.png" alt="OpenClaw" height="56"><br>OpenClaw</a>
+      <a href="https://openclaw.ai/" title="OpenClaw"><img src="assets/openclaw-logo.png" alt="OpenClaw" height="56"></a>
     </td>
     <td align="center" width="140">
-      <a href="https://www.anthropic.com/product/claude-code"><img src="assets/claudecode-color.png" alt="Claude Code" height="56"><br>Claude Code</a>
+      <a href="https://www.anthropic.com/product/claude-code" title="Claude Code"><img src="assets/claudecode-color.png" alt="Claude Code" height="56"></a>
     </td>
     <td align="center" width="140">
-      <a href="https://hermes-agent.nousresearch.com/"><img src="assets/hermes-logo.png" alt="Hermes Agent" height="56"><br>Hermes Agent</a>
+      <a href="https://hermes-agent.nousresearch.com/" title="Hermes Agent"><img src="assets/hermes-logo.png" alt="Hermes Agent" height="56"></a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
- Remove the OpenClaw / Claude Code / Hermes Agent text labels under each logo.
- Keep hover \`title\` attributes so the product name is still discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)