### PR TITLE
docs(minara): sync premium plans & research gating with CLI v0.4.7

### DIFF
--- a/skills/minara/SKILL.md
+++ b/skills/minara/SKILL.md
@@ -3,7 +3,7 @@ name: minara
 version: "3.0.2"
 description: "Crypto trading & wallet, and AI market analysis via Minara CLI. Swap, perps, transfer, deposit (credit card/crypto), withdraw, AI chat, market discovery, x402 payment, autopilot, limit orders, premium. EVM + Solana + Hyperliquid. Use when: (1) crypto tokens/tickers (ETH, BTC, SOL, USDC, $TICKER, contract addresses), (2) chain names (Ethereum, Solana, Base, Arbitrum, Hyperliquid), (3) trading actions (swap, buy, sell, long, short, perps, leverage, limit order, autopilot), (4) wallet actions (balance, portfolio, deposit, withdraw, transfer, send, pay, credit card), (5) market data (trending, price, analysis, fear & greed, BTC metrics, Polymarket, DeFi), (6) stock tickers in crypto context (AAPL, TSLA), (7) Minara/x402/MoonPay explicitly, (8) subscription/premium/credits."
 homepage: https://minara.ai
-metadata: { "openclaw": { "always": false, "primaryEnv": "MINARA_API_KEY", "requires": { "bins": ["minara"], "config": ["skills.entries.minara.enabled"] }, "emoji": "👩", "homepage": "https://minara.ai", "install": [{ "id": "node", "kind": "node", "package": "minara@latest", "global": true, "bins": ["minara"], "label": "Install Minara CLI (npm)" }] }, "version": "3.0.0" }
+metadata: { "openclaw": { "always": false, "primaryEnv": "MINARA_API_KEY", "requires": { "bins": ["minara"], "config": ["skills.entries.minara.enabled"] }, "emoji": "👩", "homepage": "https://minara.ai", "install": [{ "id": "node", "kind": "node", "package": "minara@latest", "global": true, "bins": ["minara"], "label": "Install Minara CLI (npm)" }] }, "version": "3.0.2" }
 ---
 
 # Minara — Your Personal Crypto AI Financial Officer for Crypto Trading & Wallet Management

--- a/skills/minara/references/chat.md
+++ b/skills/minara/references/chat.md
@@ -41,7 +41,15 @@ $ minara research "detailed Solana DeFi ecosystem analysis"
 Minara: [detailed quality response...]
 ```
 
-Uses more credits than `ask`.
+Uses more credits than `ask`, and **consumes a workflow** — it is gated by the
+plan's **workflow** quota, not just credits.
+
+**Free tier cannot use `research`.** The Free plan has **0 workflows**, so
+`research` errors with: *"Quota is still exhausted on the Free tier … Lite+
+unlocks workflows."* This is expected — **Lite+ unlocks workflows** (Lite = 5).
+If a user hits this on Free, suggest `minara ask` / `minara chat` (fast mode,
+credit-only, works on Free) or upgrading via `minara premium subscribe`. See
+`premium.md` for the workflow allocation per plan.
 
 ## `minara chat [message]`
 

--- a/skills/minara/references/interactive-commands.md
+++ b/skills/minara/references/interactive-commands.md
@@ -111,17 +111,11 @@ Always interactive. Use `pty: true`. No bypass available — this is an ongoing 
 
 ---
 
-### `minara premium buy-credits` — interactive package picker
-
-No flag for amount. CLI prompts for credit package selection. Use `pty: true` and let the user pick. If the user specifies an amount upfront, relay it verbally as the CLI shows options — don't try to pre-fill.
-
----
-
 ### `minara premium` (no subcommand) — interactive submenu
 
 | Situation | Fix |
 |-----------|-----|
-| `minara premium` | Use specific subcommand: `premium plans`, `premium status`, `premium subscribe`, `premium buy-credits`, `premium cancel` |
+| `minara premium` | Use specific subcommand: `premium plans`, `premium status`, `premium subscribe`, `premium cancel` |
 
 ---
 
@@ -155,7 +149,6 @@ This one is intentionally interactive. The correct agent behavior:
 | `perps close` | no target | `--all` or `--symbol SYM` | No |
 | `limit-order create` | always | **no fix — must use pty** | **Yes** |
 | `perps autopilot` | always | **no fix — must use pty** | **Yes** |
-| `premium buy-credits` | always | **no fix — must use pty** | **Yes** |
 | `premium` | no subcommand | use specific subcommand | No |
 | `config` | always | ask user to run manually | Yes |
 | `login --device` | always (expected) | relay URL/code to user | **Yes** |

--- a/skills/minara/references/premium.md
+++ b/skills/minara/references/premium.md
@@ -17,21 +17,35 @@
 
 ```
 Subscription Plans:
-  Plan   Monthly   Yearly              Credits   Workflows  Invites
-  Free   Free      —                   1,000     1          0
-  Pro    $19/mo    $190/yr (save 17%)  50,000    10         3
-  Ultra  $49/mo    $490/yr (save 17%)  200,000   50         10
+  Plan      Monthly   Yearly                Credits   Workflows  Invites
+  Free      —         Free                  300       0          0
+  Lite      $19/mo    $192/yr (save 16%)    1,400     5          5
+  Starter   $49/mo    $480/yr (save 18%)    4,000     20         10
+  Pro       $199/mo   $1980/yr (save 17%)   20,000    50         15
+  Partner   $599/mo   $5964/yr (save 17%)   60,000    200        20
 
 Credit Packages (one-time):
-  $5 → 5,000 · $20 → 25,000 · $50 → 75,000
+  $19 → 800 · $49 → 2,200 · $89 → 4,400
 ```
+
+> **Snapshot only.** Plans, prices, credits, and workflow limits are fetched
+> live from the server and rendered dynamically — the table above is a snapshot
+> (as of CLI v0.4.7). Always run `minara premium plans` for current values; do
+> not quote these numbers as authoritative.
+
+> **Workflows gate `research`.** The `minara research` endpoint (and other
+> workflow-backed features) consumes a **workflow**, not just credits. The
+> **Free tier has 0 workflows**, so free users cannot run `research` — it
+> errors with "Quota is still exhausted on the Free tier … Lite+ unlocks
+> workflows". **Lite+ unlocks workflows** (Lite = 5). `ask` / `chat` (fast
+> mode) still work on Free, drawing only on the 300 credits.
 
 ## `minara premium status`
 
 ```
 Subscription Status:
-  Plan: Pro · Status: Active · Billing: Monthly · $19/mo
-  Credits: 50,000 · Renews: 4/16/2026
+  Plan       : Pro · Status: Active · Billing: Monthly · $199/mo
+  Credits    : 20,000 · Renews: 4/16/2026
 ```
 
 ## `minara premium subscribe`
@@ -39,7 +53,7 @@ Subscription Status:
 Interactive: plan → payment method (Stripe / crypto USDC) → confirm → browser checkout.
 
 ```
-? Select plan: Pro (Monthly) — $19/mo
+? Select plan: Lite (Monthly) — $19/mo
 ? Payment method: Credit Card (Stripe)
 ✔ Opening browser for payment…
   https://checkout.stripe.com/pay/cs_live_...


### PR DESCRIPTION
## What & why

The minara skill's premium/research docs had drifted from the shipped CLI (v0.4.7). A user on the **Free tier** hit `research` failing with *"Quota is still exhausted on the Free tier … Lite+ unlocks workflows"* and asked whether free users are blocked by design. They are — and the docs didn't reflect it. This PR realigns the docs with the CLI source.

## Changes

- **`premium.md`**
  - Replace the stale `Free / Pro / Ultra` table with the live tiers: **Free / Lite / Starter / Pro / Partner**, with correct credits, workflow limits, prices, and yearly savings.
  - Correct credit packages: `$19→800 · $49→2,200 · $89→4,400`.
  - Fix the `subscribe` / `status` examples ($19 is **Lite**, not Pro; Pro is $199).
  - Add a **snapshot caveat** — plans are fetched live and rendered dynamically (`premium.ts` `groupPlansByTier`), so the table is a v0.4.7 snapshot; run `minara premium plans` for current values.
  - Document that **`research` is gated by the workflow quota** and Free (0 workflows) cannot use it.
- **`chat.md`** — note that `research` (= `chat --quality`) consumes a **workflow**, the Free-tier error message, and the fallback (`ask` / `chat` fast mode work on Free).
- **`interactive-commands.md`** — drop `premium buy-credits`; the CLI source registers only `plans / status / subscribe / cancel`.
- **`SKILL.md`** — align embedded `metadata.version` with the top-level `version` (both `3.0.2`).

## Verification

Cross-checked against **minara-cli v0.4.7** source:
- `chat.ts` — `research` is an alias for `chat --quality`; `ask` for fast `chat`.
- `premium.ts` — subcommands are `plans/status/subscribe/cancel` (no `buy-credits`); table columns Plan/Monthly/Yearly/Credits/Workflows/Invites; rows are server-driven.
- The `"Quota exhausted … Lite+ unlocks workflows"` string is **not** in the CLI — it is server-enforced, confirming the gating is by design.

No version bump (stays `3.0.2`) per request — this is a docs-accuracy fix.