### PR TITLE
Defer setup authentication until account access is needed

### DIFF
--- a/scripts/claudecode-minara-skill-setup.sh
+++ b/scripts/claudecode-minara-skill-setup.sh
@@ -184,7 +184,7 @@ fi
 # ---------------------------------------------------------------------------
 # Step 1: Install or update Minara CLI
 # ---------------------------------------------------------------------------
-echo "==> [1/4] Minara CLI..."
+echo "==> [1/3] Minara CLI..."
 if command -v minara &>/dev/null; then
   CURRENT_CLI_VER=$(minara --version 2>/dev/null || echo "0.0.0")
   CURRENT_CLI_VER="${CURRENT_CLI_VER#v}"
@@ -208,7 +208,7 @@ fi
 # Step 2: Install or update Minara skill to ~/.claude/skills/minara
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> [2/4] Minara skill..."
+echo "==> [2/3] Minara skill..."
 mkdir -p "$SKILLS_DIR"
 
 SKILL_ACTION="none"
@@ -254,63 +254,8 @@ fi
 # Step 3: Inject Minara config into ~/.claude/CLAUDE.md
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> [3/4] CLAUDE.md integration..."
+echo "==> [3/3] CLAUDE.md integration..."
 _inject_claude_md
-
-# ---------------------------------------------------------------------------
-# Step 4: Login (skip if already logged in)
-# ---------------------------------------------------------------------------
-echo ""
-echo "==> [4/4] Minara login..."
-
-ALREADY_LOGGED_IN=false
-if command -v minara &>/dev/null; then
-  if minara whoami &>/dev/null 2>&1; then
-    ALREADY_LOGGED_IN=true
-    WHOAMI=$(minara whoami 2>/dev/null || echo "")
-    echo "    Already logged in${WHOAMI:+ as $WHOAMI}"
-  fi
-fi
-
-if [[ "$ALREADY_LOGGED_IN" == false ]]; then
-  echo "    Starting device code login..."
-  echo ""
-
-  LOGIN_LOG="$TMP_DIR/minara-login.log"
-  minara login --device < /dev/null > "$LOGIN_LOG" 2>&1 &
-  LOGIN_PID=$!
-
-  PRINTED_URL=false
-  while kill -0 "$LOGIN_PID" 2>/dev/null; do
-    if [[ -f "$LOGIN_LOG" ]] && [[ "$PRINTED_URL" == false ]]; then
-      LOGIN_URL=$(grep -oE 'https?://[^ ]+' "$LOGIN_LOG" | head -1 || true)
-      if [[ -n "$LOGIN_URL" ]]; then
-        echo "============================================"
-        echo "  Open this URL to complete login:"
-        echo "  $LOGIN_URL"
-        echo ""
-        grep -i 'code' "$LOGIN_LOG" | head -1 | while read -r line; do echo "  $line"; done || true
-        echo "============================================"
-        echo ""
-        echo "  Waiting for browser verification..."
-        PRINTED_URL=true
-      fi
-    fi
-    sleep 1
-  done
-
-  wait "$LOGIN_PID" 2>/dev/null
-  LOGIN_EXIT=$?
-
-  if [[ -f "$LOGIN_LOG" ]]; then
-    cat "$LOGIN_LOG"
-  fi
-
-  if [[ "$LOGIN_EXIT" -ne 0 ]]; then
-    echo ""
-    echo "    Login failed or was cancelled. Run 'minara login' to retry."
-  fi
-fi
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -330,9 +275,7 @@ command -v minara &>/dev/null && echo "  CLI version: $(minara --version 2>/dev/
 echo "  Skill path:  $SKILLS_DIR/minara"
 echo "  Skill version: v$(_skill_version "$SKILLS_DIR/minara")"
 echo "  CLAUDE.md:   $CLAUDE_MD"
-if [[ "$ALREADY_LOGGED_IN" == true ]] || [[ "${LOGIN_EXIT:-1}" -eq 0 ]]; then
-  echo "  Logged in: yes"
-fi
+echo "  Authentication: on demand"
 echo ""
 echo "  You can now use Minara in Claude Code for crypto trading,"
 echo "  market data, perpetual futures, and more. Try asking:"

--- a/scripts/hermes-minara-skill-setup.sh
+++ b/scripts/hermes-minara-skill-setup.sh
@@ -184,7 +184,7 @@ fi
 # ---------------------------------------------------------------------------
 # Step 1: Install or update Minara CLI
 # ---------------------------------------------------------------------------
-echo "==> [1/4] Minara CLI..."
+echo "==> [1/3] Minara CLI..."
 if command -v minara &>/dev/null; then
   CURRENT_CLI_VER=$(minara --version 2>/dev/null || echo "0.0.0")
   CURRENT_CLI_VER="${CURRENT_CLI_VER#v}"
@@ -208,7 +208,7 @@ fi
 # Step 2: Install or update Minara skill to ~/.hermes/skills/minara
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> [2/4] Minara skill..."
+echo "==> [2/3] Minara skill..."
 mkdir -p "$SKILLS_DIR"
 
 SKILL_ACTION="none"
@@ -254,63 +254,8 @@ fi
 # Step 3: Inject Minara config into ~/.hermes/memories/MEMORY.md
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> [3/4] MEMORY.md integration..."
+echo "==> [3/3] MEMORY.md integration..."
 _inject_memory_md
-
-# ---------------------------------------------------------------------------
-# Step 4: Login (skip if already logged in)
-# ---------------------------------------------------------------------------
-echo ""
-echo "==> [4/4] Minara login..."
-
-ALREADY_LOGGED_IN=false
-if command -v minara &>/dev/null; then
-  if minara whoami &>/dev/null 2>&1; then
-    ALREADY_LOGGED_IN=true
-    WHOAMI=$(minara whoami 2>/dev/null || echo "")
-    echo "    Already logged in${WHOAMI:+ as $WHOAMI}"
-  fi
-fi
-
-if [[ "$ALREADY_LOGGED_IN" == false ]]; then
-  echo "    Starting device code login..."
-  echo ""
-
-  LOGIN_LOG="$TMP_DIR/minara-login.log"
-  minara login --device < /dev/null > "$LOGIN_LOG" 2>&1 &
-  LOGIN_PID=$!
-
-  PRINTED_URL=false
-  while kill -0 "$LOGIN_PID" 2>/dev/null; do
-    if [[ -f "$LOGIN_LOG" ]] && [[ "$PRINTED_URL" == false ]]; then
-      LOGIN_URL=$(grep -oE 'https?://[^ ]+' "$LOGIN_LOG" | head -1 || true)
-      if [[ -n "$LOGIN_URL" ]]; then
-        echo "============================================"
-        echo "  Open this URL to complete login:"
-        echo "  $LOGIN_URL"
-        echo ""
-        grep -i 'code' "$LOGIN_LOG" | head -1 | while read -r line; do echo "  $line"; done || true
-        echo "============================================"
-        echo ""
-        echo "  Waiting for browser verification..."
-        PRINTED_URL=true
-      fi
-    fi
-    sleep 1
-  done
-
-  wait "$LOGIN_PID" 2>/dev/null
-  LOGIN_EXIT=$?
-
-  if [[ -f "$LOGIN_LOG" ]]; then
-    cat "$LOGIN_LOG"
-  fi
-
-  if [[ "$LOGIN_EXIT" -ne 0 ]]; then
-    echo ""
-    echo "    Login failed or was cancelled. Run 'minara login' to retry."
-  fi
-fi
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -330,9 +275,7 @@ command -v minara &>/dev/null && echo "  CLI version: $(minara --version 2>/dev/
 echo "  Skill path:  $SKILLS_DIR/minara"
 echo "  Skill version: v$(_skill_version "$SKILLS_DIR/minara")"
 echo "  MEMORY.md:   $MEMORY_MD"
-if [[ "$ALREADY_LOGGED_IN" == true ]] || [[ "${LOGIN_EXIT:-1}" -eq 0 ]]; then
-  echo "  Logged in: yes"
-fi
+echo "  Authentication: on demand"
 echo ""
 echo "  You can now use Minara in Hermes for crypto trading,"
 echo "  market data, perpetual futures, and more. Try asking:"

--- a/scripts/openclaw-minara-skill-setup.sh
+++ b/scripts/openclaw-minara-skill-setup.sh
@@ -248,7 +248,7 @@ fi
 # ---------------------------------------------------------------------------
 # Step 1: Install or update Minara CLI
 # ---------------------------------------------------------------------------
-echo "==> [1/5] Minara CLI..."
+echo "==> [1/4] Minara CLI..."
 if command -v minara &>/dev/null; then
   CURRENT_CLI_VER=$(minara --version 2>/dev/null || echo "0.0.0")
   CURRENT_CLI_VER="${CURRENT_CLI_VER#v}"
@@ -272,7 +272,7 @@ fi
 # Step 2: Install or update Minara skill
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> [2/5] Minara skill..."
+echo "==> [2/4] Minara skill..."
 mkdir -p "$SKILLS_DIR"
 
 SKILL_ACTION="none"
@@ -318,7 +318,7 @@ fi
 # Step 3: Enable minara in openclaw.json
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> [3/5] OpenClaw config..."
+echo "==> [3/4] OpenClaw config..."
 CONFIG_PATH="$(_resolve_config_path "$CONFIG_PATH")"
 _ensure_minara_config "$CONFIG_PATH"
 
@@ -326,64 +326,9 @@ _ensure_minara_config "$CONFIG_PATH"
 # Step 4: Workspace integration (AGENTS.md + MEMORY.md)
 # ---------------------------------------------------------------------------
 echo ""
-echo "==> [4/5] Workspace integration..."
+echo "==> [4/4] Workspace integration..."
 _inject_agents_prompt
 _inject_memory
-
-# ---------------------------------------------------------------------------
-# Step 5: Login (skip if already logged in)
-# ---------------------------------------------------------------------------
-echo ""
-echo "==> [5/5] Minara login..."
-
-ALREADY_LOGGED_IN=false
-if command -v minara &>/dev/null; then
-  if minara whoami &>/dev/null 2>&1; then
-    ALREADY_LOGGED_IN=true
-    WHOAMI=$(minara whoami 2>/dev/null || echo "")
-    echo "    Already logged in${WHOAMI:+ as $WHOAMI}"
-  fi
-fi
-
-if [[ "$ALREADY_LOGGED_IN" == false ]]; then
-  echo "    Starting device code login..."
-  echo ""
-
-  LOGIN_LOG="$TMP_DIR/minara-login.log"
-  minara login --device < /dev/null > "$LOGIN_LOG" 2>&1 &
-  LOGIN_PID=$!
-
-  PRINTED_URL=false
-  while kill -0 "$LOGIN_PID" 2>/dev/null; do
-    if [[ -f "$LOGIN_LOG" ]] && [[ "$PRINTED_URL" == false ]]; then
-      LOGIN_URL=$(grep -oE 'https?://[^ ]+' "$LOGIN_LOG" | head -1 || true)
-      if [[ -n "$LOGIN_URL" ]]; then
-        echo "============================================"
-        echo "  Open this URL to complete login:"
-        echo "  $LOGIN_URL"
-        echo ""
-        grep -i 'code' "$LOGIN_LOG" | head -1 | while read -r line; do echo "  $line"; done || true
-        echo "============================================"
-        echo ""
-        echo "  Waiting for browser verification..."
-        PRINTED_URL=true
-      fi
-    fi
-    sleep 1
-  done
-
-  wait "$LOGIN_PID" 2>/dev/null
-  LOGIN_EXIT=$?
-
-  if [[ -f "$LOGIN_LOG" ]]; then
-    cat "$LOGIN_LOG"
-  fi
-
-  if [[ "$LOGIN_EXIT" -ne 0 ]]; then
-    echo ""
-    echo "    Login failed or was cancelled. Run 'minara login' to retry."
-  fi
-fi
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -401,9 +346,7 @@ echo "============================================"
 echo ""
 command -v minara &>/dev/null && echo "  CLI version: $(minara --version 2>/dev/null || echo 'ok')"
 echo "  Skill version: v$(_skill_version "$SKILLS_DIR/minara")"
-if [[ "$ALREADY_LOGGED_IN" == true ]] || [[ "${LOGIN_EXIT:-1}" -eq 0 ]]; then
-  echo "  Logged in: yes"
-fi
+echo "  Authentication: on demand"
 echo ""
 echo "  You can now use Minara for crypto trading, market data,"
 echo "  perpetual futures, and more. Try asking:"

--- a/skills/minara/SKILL.md
+++ b/skills/minara/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: minara
-version: "3.0.3"
+version: "3.0.4"
 description: "Crypto trading & wallet, and AI market analysis via Minara CLI. Swap, perps, transfer, deposit (credit card/crypto), withdraw, AI chat, market discovery, x402 payment, autopilot, limit orders, premium. EVM + Solana + Hyperliquid. Use when: (1) crypto tokens/tickers (ETH, BTC, SOL, USDC, $TICKER, contract addresses), (2) chain names (Ethereum, Solana, Base, Arbitrum, Hyperliquid), (3) trading actions (swap, buy, sell, long, short, perps, leverage, limit order, autopilot), (4) wallet actions (balance, portfolio, deposit, withdraw, transfer, send, pay, credit card), (5) market data (trending, price, analysis, fear & greed, BTC metrics, Polymarket, DeFi), (6) stock tickers in crypto context (AAPL, TSLA), (7) Minara/x402/MoonPay explicitly, (8) subscription/premium/credits."
 homepage: https://minara.ai
-metadata: { "openclaw": { "always": false, "primaryEnv": "MINARA_API_KEY", "requires": { "bins": ["minara"], "config": ["skills.entries.minara.enabled"] }, "emoji": "👩", "homepage": "https://minara.ai", "install": [{ "id": "node", "kind": "node", "package": "minara@latest", "global": true, "bins": ["minara"], "label": "Install Minara CLI (npm)" }] }, "version": "3.0.3" }
+metadata: { "openclaw": { "always": false, "primaryEnv": "MINARA_API_KEY", "requires": { "bins": ["minara"], "config": ["skills.entries.minara.enabled"] }, "emoji": "👩", "homepage": "https://minara.ai", "install": [{ "id": "node", "kind": "node", "package": "minara@latest", "global": true, "bins": ["minara"], "label": "Install Minara CLI (npm)" }] }, "version": "3.0.4" }
 ---
 
 # Minara — Your Personal Crypto AI Financial Officer for Crypto Trading & Wallet Management


### PR DESCRIPTION
## Summary
- remove automatic account probes and device login from all setup scripts
- keep authentication lazy after installation and during skill activation
- report on-demand authentication in setup summaries

## Validation
- bash syntax checks passed for all setup scripts
- no setup script contains whoami or login calls
- MINARA_API_KEY bypass documentation remains unchanged